### PR TITLE
Update Go to v1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21"
+          go-version: ">=1.26"
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csweichel/oci-tool
 
-go 1.21
+go 1.26
 
 require (
 	github.com/containerd/containerd v1.7.8


### PR DESCRIPTION
Bump the Go version from 1.21 to 1.26 in `go.mod` and the CI workflow.

### Changes
- `go.mod`: `go 1.21` → `go 1.26`
- `.github/workflows/build.yml`: `go-version: ">=1.21"` → `go-version: ">=1.26"`